### PR TITLE
Refactor, per-feature env vars, pass feature name

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,16 @@ This will match:
 * uid against the percentage `ROLLOUT_FEATURE_PERCENT`
 * remaining arg values against the env vars `ROLLOUT_FEATURE_USERS` and `ROLLOUT_FEATURE_REPOS` (as comma separated values)
 
-`uid` can be a string or integer. For a string it will calculate the crc32 to
-turn it into an integer.
+For example:
+
+```
+ROLLOUT=feature_foo
+ROLLOUT_FEATURE_FOO_OWNERS=joecorcoran,svenfuchs
+ROLLOUT_FEATURE_FOO_PERCENT=5
+```
+
+The `uid` passed can be a string or integer. For a string it will calculate the
+crc32 to turn it into an integer.
 
 If a redis instance is passed as an option it will additionally check redis:
 

--- a/README.md
+++ b/README.md
@@ -6,16 +6,21 @@ Enable by setting an env var `ROLLOUT` and setting `ENV` to `production` or
 ## Usage
 
 ```ruby
-args = { uid: 1, user: 'svenfuchs', repo: 'travis-hub' }
-Travis::Rollout.run(args) do
-  # reroute the message
+args = {
+  uid:  1
+  user: 'svenfuchs',
+  repo: 'travis-hub'
+}
+
+Rollout.run(:feature, args) do
+  # only runs when active
 end
 ```
 
 This will match:
 
-* uid against the percentage `ROLLOUT_PERCENT`
-* remaining arg values against the env vars `ROLLOUT_USERS` and `ROLLOUT_REPOS` (as comma separated values)
+* uid against the percentage `ROLLOUT_FEATURE_PERCENT`
+* remaining arg values against the env vars `ROLLOUT_FEATURE_USERS` and `ROLLOUT_FEATURE_REPOS` (as comma separated values)
 
 `uid` can be a string or integer. For a string it will calculate the crc32 to
 turn it into an integer.
@@ -23,8 +28,8 @@ turn it into an integer.
 If a redis instance is passed as an option it will additionally check redis:
 
 ```ruby
-Travis::Rollout.run(args, redis: redis) do
-  # reroute the message
+Travis::Rollout.run(feature, args.merge(redis: redis)) do
+  # only runs when active
 end
 ```
 
@@ -33,3 +38,5 @@ It will use the value of the env var `ROLLOUT` as a namespace (e.g. `sync`), and
 * enabling: `sync.rollout.enabled`
 * args: `sync.rollout.users`, `sync.rollout.repos`, `sync.rollout.owners`
 * percentage: `sync.rollout.percent`
+
+Values stored in Redis will take precedence over values stored in the ENV.

--- a/lib/travis/rollout.rb
+++ b/lib/travis/rollout.rb
@@ -76,7 +76,7 @@ module Travis
       new(*all).matches?
     end
 
-    attr_reader :name, :args, :env, :redis
+    attr_reader :name, :args, :block, :redis, :env
 
     def initialize(name, args, &block)
       @name  = name

--- a/lib/travis/rollout.rb
+++ b/lib/travis/rollout.rb
@@ -3,12 +3,6 @@ require 'zlib'
 module Travis
   class Rollout
     class Env < Struct.new(:name)
-      ENVS = %w(production staging)
-
-      def production?
-        ENVS.include?(ENV['ENV'])
-      end
-
       def enabled?
         names.include?(name)
       end
@@ -97,7 +91,7 @@ module Travis
     end
 
     def matches?
-      env.production? and enabled? and (by_value? or by_percent?)
+      enabled? and (by_value? or by_percent?)
     end
 
     private

--- a/lib/travis/rollout.rb
+++ b/lib/travis/rollout.rb
@@ -10,15 +10,15 @@ module Travis
       end
 
       def enabled?
-        names.include?(name)
+        names.include?(name.to_s)
       end
 
       def values(key)
-        ENV["ROLLOUT_#{name.upcase}_#{key.to_s.upcase}S"].to_s.split(',')
+        ENV["ROLLOUT_#{name.to_s.upcase}_#{key.to_s.upcase}S"].to_s.split(',')
       end
 
       def percent
-        ENV["ROLLOUT_#{name.upcase}_PERCENT"]
+        ENV["ROLLOUT_#{name.to_s.upcase}_PERCENT"]
       end
 
       def names

--- a/lib/travis/rollout.rb
+++ b/lib/travis/rollout.rb
@@ -35,10 +35,13 @@ module Travis
       new(*all).matches?
     end
 
-    attr_reader :args, :options, :block
+    attr_reader :key, :args, :redis
 
-    def initialize(args = {}, options = {}, &block)
-      @args, @options, @block = args, options, block
+    def initialize(key, args, &block)
+      @key   = key
+      @args  = args
+      @block = block
+      @redis = args.delete(:redis)
     end
 
     def run
@@ -117,10 +120,6 @@ module Travis
 
       def name
         ENV['ROLLOUT'].to_s.split('.').first
-      end
-
-      def redis
-        options[:redis]
       end
 
       def camelize(string)

--- a/spec/rollout_spec.rb
+++ b/spec/rollout_spec.rb
@@ -107,38 +107,22 @@ describe Travis::Rollout do
 
   shared_examples_for 'matches by' do |type|
     context 'with ROLLOUT being set to another name' do
-      before { ENV['ENV'] = 'production' }
       before { ENV['ROLLOUT'] = 'something_else' }
       include_examples "does not match by #{type}"
     end
 
     context 'with ROLLOUT being set to another name, but [name].rollout.enabled being set in redis' do
-      before { ENV['ENV'] = 'production' }
       before { ENV['ROLLOUT'] = 'something_else' }
       before { redis.set("#{name}.rollout.enabled", '1') }
       include_examples "matches by #{type}"
     end
 
-    context 'with ROLLOUT being set in production' do
-      before { ENV['ENV'] = 'production' }
+    context 'with ROLLOUT being set' do
       before { ENV['ROLLOUT'] = name }
       include_examples "matches by #{type}"
     end
 
-    context 'with ROLLOUT being set in staging' do
-      before { ENV['ENV'] = 'production' }
-      before { ENV['ROLLOUT'] = name }
-      include_examples "matches by #{type}"
-    end
-
-    context 'with ROLLOUT being set in development' do
-      before { ENV['ENV'] = 'development' }
-      before { ENV['ROLLOUT'] = name }
-      include_examples "does not match by #{type}"
-    end
-
-    context 'with ROLLOUT not set in production' do
-      before { ENV['ENV'] = 'production' }
+    context 'with ROLLOUT not being set' do
       include_examples "does not match by #{type}"
     end
   end

--- a/spec/rollout_spec.rb
+++ b/spec/rollout_spec.rb
@@ -137,7 +137,7 @@ describe Travis::Rollout do
     let(:id)      { '517be336-f16d-45cf-aa9b-a429547af6ad' }
     let(:owner)   { 'carlad' }
     let(:repo)    { 'travis-ci/travis-hub' }
-    let(:rollout) { described_class.new({ uid: id, owner: owner, repo: repo }, redis: redis) }
+    let(:rollout) { described_class.new(name, uid: id, owner: owner, repo: repo, redis: redis) }
 
     include_examples 'matches by', 'owner name'
     include_examples 'matches by', 'repo slug'
@@ -151,7 +151,7 @@ describe Travis::Rollout do
     describe 'in the user sync worker' do
       let(:id)      { 1 }
       let(:user)    { 'carlad' }
-      let(:rollout) { described_class.new({ uid: id, user: user }, redis: redis) }
+      let(:rollout) { described_class.new(name, uid: id, user: user, redis: redis) }
 
       include_examples 'matches by', 'user name'
       include_examples 'matches by', 'percentage'
@@ -160,7 +160,7 @@ describe Travis::Rollout do
     describe 'in the repo branches sync worker' do
       let(:id)      { 1 } # user id
       let(:owner)   { 'carlad' }
-      let(:rollout) { described_class.new({ uid: id, owner: owner }, redis: redis) }
+      let(:rollout) { described_class.new(name, uid: id, owner: owner, redis: redis) }
 
       include_examples 'matches by', 'owner name'
       include_examples 'matches by', 'percentage'


### PR DESCRIPTION
This changes the signature to:

```
Travis::Rollout.match?(:feature_name, uid: 1, redis: redis)
```

It also uses per-feature ENV vars, e.g. with `:feature_name` passed it would check for:

```
ROLLOUT=feature_name
ROLLOUT_FEATURE_NAME_PERCENT=5
ROLLOUT_FEATURE_NAME_OWNERS=svenfuchs
# etc.
```

It also allows to enable several features for rollout with the ENV var:

```
ROLLOUT=feature_one,feature_two
```

(Of course, these still also could be enabled via Redis separately.)